### PR TITLE
ENTESB-14969 Link Secrets Creation page to Quickstarts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,15 +27,15 @@ The most effective way to run this quickstart is to deploy and run the project o
 
 For more details about running this quickstart on a single-node OpenShift cluster, CI/CD deployments, as well as the rest of the runtime, see the link:http://appdev.openshift.io/docs/spring-boot-runtime.html[Spring Boot Runtime Guide].
 
-== Running the Quickstart on a single-node Kubernetes/OpenShift cluster
+== Running the Quickstart on a single-node Kubernetese/OpenShift cluster
 
 IMPORTANT: You need to run this example on Container Development Kit 3.3 or OpenShift 3.7.
 Both of these products have suitable Fuse images pre-installed.
 If you run it in an environment where those images are not preinstalled follow the steps described in <<single-node-without-preinstalled-images>>.
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -68,16 +68,16 @@ $ mvn clean -DskipTests oc:deploy -Popenshift
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
 Wait until you can see that the pod for the `spring-boot-camel-drools` has started up.
 
-. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-drool` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/rc/spring-boot-camel-drools-NUMBER_OF_DEPLOYMENT?tab=details`.
+. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-drools` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/rc/spring-boot-camel-drools-NUMBER_OF_DEPLOYMENT?tab=details`.
 
 . Switch to tab `Logs` and then see the messages sent by Camel.
 
 [#single-node-without-preinstalled-images]
-=== Running the Quickstart on a single-node Kubernetes/OpenShift cluster without preinstalled images
+=== Running the Quickstart on a single-node Kubernetese/OpenShift cluster without preinstalled images
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -93,11 +93,14 @@ $ oc login -u developer -p developer
 $ oc new-project MY_PROJECT_NAME
 ----
 
-. Import base images in your newly created project (MY_PROJECT_NAME):
+. Configure Red Hat Container Registry authentication (if it is not configured).
+Follow https://access.redhat.com/documentation/en-us/red_hat_fuse/7.9/html-single/fuse_on_openshift_guide/index#configure-container-registry[documentation].
+
+. Import base images in your newly created project (MY_PROJECT_NAME). :
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc import-image fuse-java-openshift:2.0 --from=registry.access.redhat.com/jboss-fuse-7/fuse-java-openshift:2.0 --confirm
+$ oc import-image fuse-java-openshift:1.9 --from=registry.redhat.io/fuse7/fuse-java-openshift:1.9 --confirm
 ----
 
 . Change the directory to the folder that contains the extracted quickstart application (for example, `my_openshift/spring-boot-camel-drools`) :
@@ -111,13 +114,13 @@ $ cd my_openshift/spring-boot-camel-drools
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean -DskipTests oc:deploy -Popenshift -Djkube.generator.fromMode=istag -Djkube.generator.from=MY_PROJECT_NAME/fuse-java-openshift:2.0
+$ mvn clean -DskipTests oc:deploy -Popenshift -Djkube.generator.fromMode=istag -D=jkube.generator.from=MY_PROJECT_NAME/fuse-java-openshift:1.9
 ----
 
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
 Wait until you can see that the pod for the `spring-boot-camel-drools` has started up.
 
-. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-drool` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/rc/spring-boot-camel-drools-NUMBER_OF_DEPLOYMENT?tab=details`.
+. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-drools` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/rc/spring-boot-camel-drools-NUMBER_OF_DEPLOYMENT?tab=details`.
 
 . Switch to tab `Logs` and then see the messages sent by Camel.
 
@@ -140,4 +143,9 @@ $ mvn clean package
 ----
 $ mvn spring-boot:run
 ----
+
 . See the messages sent by Camel.
+
+---
+
+Generated by maven plugin - do NOT edit this file! (See https://github.com/jboss-fuse/documentation-template/blob/main/README.md[documentation])

--- a/src/main/doc/introduction-other.adoc
+++ b/src/main/doc/introduction-other.adoc
@@ -1,0 +1,9 @@
+== Kie Server Configuration
+
+The Kie Server should be deployed before running the application and the classic `hellorule` example should be installed and activated. The example is based on the `Person` and `Greeting` facts. The Camel route will periodically add a `Person` fact into the remote knowledge base and retrieve a `Greeting` created by the rule.
+
+The `hellorule` example is installed by default into the Openshift Decision Server xPaaS Image when using the `decisionserver64-basic-s2i` template with the default configuration (the `hellorule` source code is contained in the default git repository used by the template). If the Decision Server xPaaS image is used, access to the rest API is restricted to authenticated users, so the same _username_ and _password_ combination chosen in the Decision Server xPaaS template must be used in the configuration of the current this quickstart.
+
+**Note**: Username and password as well as the service name of the Kie Server for the current quickstart can be set in the `application.properties` file (especially when running this quickstart using the openshift-maven-plugin) or from the Openshift creation wizard when the S2I template is used.
+
+Configuration through the application.properties file can also be useful when running the quickstart locally.

--- a/src/main/doc/introduction.adoc
+++ b/src/main/doc/introduction.adoc
@@ -1,0 +1,5 @@
+== Spring-Boot Camel-Drools QuickStart
+
+This example demonstrates how you can use Apache Camel to integrate a Spring-Boot application running on Kubernetes or OpenShift with a remote Kie Server.
+
+The application utilizes the Spring http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/ImportResource.html[`@ImportResource`] annotation to load a Camel Context definition via a _src/main/resources/spring/camel-context.xml_ file on the classpath.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-14969

Change refactors quickstart to use a template for documentation + template adds missing instruction to add secret.